### PR TITLE
Fix SparsePLS

### DIFF
--- a/biospectools/models/sparse_pls.py
+++ b/biospectools/models/sparse_pls.py
@@ -139,8 +139,7 @@ class SparsePLSRegression(_pls._PLS):
                  scale=False, max_iter=500, tol=1e-6, copy=True):
         super().__init__(
             n_components, scale=scale, algorithm='svd',
-            deflation_mode="regression", norm_y_weights=False,
-            max_iter=max_iter, tol=tol, copy=copy)
+            deflation_mode="regression", max_iter=max_iter, tol=tol, copy=copy)
 
         if isinstance(sparsity, float):
             self.sparsity = np.full(n_components, sparsity)


### PR DESCRIPTION
Remove norm_y_weights parameter, since it is removed in the new sklearn

Back compatibility is OK, since the default value of norm_y_weights is passed, so it was unnecessary to write at all.