### PR TITLE
Replace deprecated method pinv2 with pinv. Scipy required >=1.7

### DIFF
--- a/src/biospectools/models/_pls.py
+++ b/src/biospectools/models/_pls.py
@@ -10,9 +10,11 @@ The :mod:`sklearn.pls` module implements Partial Least Squares (PLS).
 
 import warnings
 from abc import ABCMeta, abstractmethod
+from packaging import version
 
 import numpy as np
-from scipy.linalg import pinv2, svd
+import scipy
+from scipy.linalg import svd
 from scipy.sparse.linalg import svds
 
 from sklearn.base import BaseEstimator, RegressorMixin, TransformerMixin
@@ -24,6 +26,14 @@ from sklearn.utils.validation import _deprecate_positional_args
 from sklearn.exceptions import ConvergenceWarning
 
 __all__ = ['PLSCanonical', 'PLSRegression', 'PLSSVD']
+
+
+if version.parse(scipy.__version__) >= version.parse("1.7"):
+    # Starting in scipy 1.7 pinv2 was deprecated in favor of pinv.
+    # pinv now uses the svd to compute the pseudo-inverse.
+    from scipy.linalg import pinv as pinv2
+else:
+    from scipy.linalg import pinv2
 
 
 def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,

--- a/src/biospectools/models/sparse_pls.py
+++ b/src/biospectools/models/sparse_pls.py
@@ -1,10 +1,19 @@
 import warnings
+from packaging import version
 
 import numpy as np
-from scipy.linalg import pinv2
+import scipy
 from . import _pls
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_array, check_consistent_length
+
+
+if version.parse(scipy.__version__) >= version.parse("1.7"):
+    # Starting in scipy 1.7 pinv2 was deprecated in favor of pinv.
+    # pinv now uses the svd to compute the pseudo-inverse.
+    from scipy.linalg import pinv as pinv2
+else:
+    from scipy.linalg import pinv2
 
 
 class SparsePLSRegression(_pls._PLS):


### PR DESCRIPTION
We replaced `scipy.linalg.pinv2` uses with `pinv` to make it compatible with all packages after scipy 1.7